### PR TITLE
Add compiler objective and AGENTS instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,7 @@
+# AGENTS Instructions
+
+- Read `README.md` to understand the purpose of this project. The repository aims
+  to build a self-hosted compiler that compiles the Magma language to C.
+- Keep the README up to date when code or project goals change.
+- Update this `AGENTS.md` file with any new guidelines for future agents.
+- Always run `pytest` and ensure the tests pass before committing changes.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Magmac
 
-This repository starts with basic boilerplate for a Python package.
+Magmac is an experiment in building a self-hosted compiler. The goal is to
+compile a custom language, **Magma**, to C. This repository currently starts
+with basic Python package boilerplate and will evolve into the compiler
+implementation.
 
 ## Setup
 


### PR DESCRIPTION
## Summary
- document that Magmac will become a self-hosted compiler
- add instructions for future agents in `AGENTS.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d0498d6388321b7aff1c5981c6b7f