### PR TITLE
Implement file-based output generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ Run the CLI entry point:
 python -m magmac
 ```
 
+To create an output file based on an existing input file:
+
+```bash
+python -m magmac -i path/to/input.mg -o path/to/output.c
+```
+
 ## Running Tests
 
 Install test requirements and run `pytest`:

--- a/magmac/__main__.py
+++ b/magmac/__main__.py
@@ -1,13 +1,22 @@
 """CLI entry point for Magmac."""
 
 import argparse
+from pathlib import Path
 
 
 def main(argv=None):
     parser = argparse.ArgumentParser(description="Magmac CLI")
     parser.add_argument("--version", action="version", version="Magmac 0.1.0")
+    parser.add_argument("-i", "--input", help="Input file")
+    parser.add_argument("-o", "--output", help="Output file")
     args = parser.parse_args(argv)
+
     print("Hello from Magmac!")
+
+    if args.input and args.output:
+        if Path(args.input).exists():
+            Path(args.output).touch()
+            print(f"Created {args.output}")
 
 
 if __name__ == "__main__":

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -10,3 +10,11 @@ def test_main_output(capsys):
     main([])
     captured = capsys.readouterr()
     assert "Hello from Magmac!" in captured.out
+
+
+def test_create_output_file(tmp_path):
+    input_file = tmp_path / "in.txt"
+    input_file.write_text("data")
+    output_file = tmp_path / "out.txt"
+    main(["-i", str(input_file), "-o", str(output_file)])
+    assert output_file.exists()


### PR DESCRIPTION
## Summary
- extend CLI with `--input` and `--output` options
- create an output file if the specified input file exists
- document the new behaviour in the README
- test creating an output file

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d0580dd8483218b40751193cbf3dd