### PR TITLE
Implement simple Magma to C compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,20 @@ To create an output file based on an existing input file:
 python -m magmac -i path/to/input.mg -o path/to/output.c
 ```
 
+Currently the compiler supports a minimal syntax. A function declaration
+`fn name() => {}` is translated into an empty C function:
+
+```magma
+fn empty() => {}
+```
+
+produces the following C code:
+
+```c
+void empty(void) {
+}
+```
+
 ## Running Tests
 
 Install test requirements and run `pytest`:

--- a/magmac/__main__.py
+++ b/magmac/__main__.py
@@ -3,6 +3,8 @@
 import argparse
 from pathlib import Path
 
+from .compiler import compile_file
+
 
 def main(argv=None):
     parser = argparse.ArgumentParser(description="Magmac CLI")
@@ -14,8 +16,10 @@ def main(argv=None):
     print("Hello from Magmac!")
 
     if args.input and args.output:
-        if Path(args.input).exists():
-            Path(args.output).touch()
+        in_path = Path(args.input)
+        out_path = Path(args.output)
+        if in_path.exists():
+            compile_file(in_path, out_path)
             print(f"Created {args.output}")
 
 

--- a/magmac/compiler.py
+++ b/magmac/compiler.py
@@ -1,0 +1,19 @@
+import re
+from pathlib import Path
+
+
+def compile_source(source: str) -> str:
+    """Compile a Magma source string to C code."""
+    pattern = re.compile(r"fn\s+(\w+)\s*\(\)\s*=>\s*{\s*}")
+    output_lines = []
+    for match in pattern.finditer(source):
+        name = match.group(1)
+        output_lines.append(f"void {name}(void) {{\n}}\n")
+    return "".join(output_lines)
+
+
+def compile_file(input_path: Path, output_path: Path) -> None:
+    """Compile a file containing Magma code into a C file."""
+    src = input_path.read_text()
+    c_code = compile_source(src)
+    output_path.write_text(c_code)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -12,9 +12,9 @@ def test_main_output(capsys):
     assert "Hello from Magmac!" in captured.out
 
 
-def test_create_output_file(tmp_path):
-    input_file = tmp_path / "in.txt"
-    input_file.write_text("data")
-    output_file = tmp_path / "out.txt"
+def test_compile_empty_function(tmp_path):
+    input_file = tmp_path / "in.mg"
+    input_file.write_text("fn empty() => {}")
+    output_file = tmp_path / "out.c"
     main(["-i", str(input_file), "-o", str(output_file)])
-    assert output_file.exists()
+    assert output_file.read_text() == "void empty(void) {\n}\n"


### PR DESCRIPTION
## Summary
- implement a minimal compiler that converts `fn name() => {}` into an empty C
  function
- hook the compiler into the CLI
- update tests for the new compilation behaviour
- document minimal syntax in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d0629d35483219a150575984b0fc4