### PR TITLE
Add boolean return support

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,26 @@ void empty(void) {
 }
 ```
 
+Functions can also return booleans using `true` or `false` as the body. The
+generated C uses `int` and returns `1` or `0`:
+
+```magma
+fn truthy() => true
+fn falsy() => false
+```
+
+produces:
+
+```c
+int truthy(void) {
+    return 1;
+}
+
+int falsy(void) {
+    return 0;
+}
+```
+
 ## Running Tests
 
 Install test requirements and run `pytest`:

--- a/magmac/compiler.py
+++ b/magmac/compiler.py
@@ -4,11 +4,21 @@ from pathlib import Path
 
 def compile_source(source: str) -> str:
     """Compile a Magma source string to C code."""
-    pattern = re.compile(r"fn\s+(\w+)\s*\(\)\s*=>\s*{\s*}")
+    pattern = re.compile(
+        r"fn\s+(\w+)\s*\(\)\s*=>\s*(true|false|\{\s*\})",
+        re.IGNORECASE,
+    )
     output_lines = []
     for match in pattern.finditer(source):
         name = match.group(1)
-        output_lines.append(f"void {name}(void) {{\n}}\n")
+        body = match.group(2)
+        if body.startswith("{"):
+            output_lines.append(f"void {name}(void) {{\n}}\n")
+            continue
+        value = "1" if body.lower() == "true" else "0"
+        output_lines.append(
+            f"int {name}(void) {{\n    return {value};\n}}\n"
+        )
     return "".join(output_lines)
 
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -18,3 +18,19 @@ def test_compile_empty_function(tmp_path):
     output_file = tmp_path / "out.c"
     main(["-i", str(input_file), "-o", str(output_file)])
     assert output_file.read_text() == "void empty(void) {\n}\n"
+
+
+def test_compile_boolean_functions(tmp_path):
+    src = "\n".join([
+        "fn truthy() => true",
+        "fn falsy() => false",
+    ])
+    input_file = tmp_path / "in.mg"
+    input_file.write_text(src)
+    output_file = tmp_path / "out.c"
+    main(["-i", str(input_file), "-o", str(output_file)])
+    expected = (
+        "int truthy(void) {\n    return 1;\n}\n"
+        "int falsy(void) {\n    return 0;\n}\n"
+    )
+    assert output_file.read_text() == expected


### PR DESCRIPTION
## Summary
- support `true` and `false` function bodies in the compiler
- document boolean return syntax in README
- test boolean-returning functions
- refactor compiler logic to limit nesting

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d08f986c08321a2cd9186e72faf22