### PR TITLE
Support integer functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,29 @@ int falsy(void) {
 }
 ```
 
+Functions may also specify integer types. In Magma, types are written in
+CamelCase, so integer types are `U8`, `U16`, `U32`, `U64`,
+`I8`, `I16`, `I32`, and `I64`. Using one of these in the function body
+generates a function returning the corresponding C integer type. Each function
+returns `0` by default:
+
+```magma
+fn byte() => U8
+fn word() => I32
+```
+
+produces:
+
+```c
+uint8_t byte(void) {
+    return 0;
+}
+
+int32_t word(void) {
+    return 0;
+}
+```
+
 ## Running Tests
 
 Install test requirements and run `pytest`:
@@ -76,3 +99,7 @@ pytest
 ## Continuous Integration
 
 This project uses GitHub Actions to run the test suite on pushes and pull requests.
+
+## Coding Style
+
+Magmac keeps nested loops and conditionals to at most two levels of indentation so the code stays readable.

--- a/magmac/compiler.py
+++ b/magmac/compiler.py
@@ -1,24 +1,38 @@
 import re
 from pathlib import Path
 
+INT_TYPES = {
+    "U8": "uint8_t",
+    "U16": "uint16_t",
+    "U32": "uint32_t",
+    "U64": "uint64_t",
+    "I8": "int8_t",
+    "I16": "int16_t",
+    "I32": "int32_t",
+    "I64": "int64_t",
+}
+
+
+def _translate_function(name: str, body: str) -> str:
+    """Return the C code for a single function declaration."""
+    if body.startswith("{"):
+        return f"void {name}(void) {{\n}}\n"
+    if body in {"true", "false"}:
+        value = "1" if body == "true" else "0"
+        return f"int {name}(void) {{\n    return {value};\n}}\n"
+    c_type = INT_TYPES[body]
+    return f"{c_type} {name}(void) {{\n    return 0;\n}}\n"
+
 
 def compile_source(source: str) -> str:
     """Compile a Magma source string to C code."""
     pattern = re.compile(
-        r"fn\s+(\w+)\s*\(\)\s*=>\s*(true|false|\{\s*\})",
-        re.IGNORECASE,
+        r"fn\s+(\w+)\s*\(\)\s*=>\s*(true|false|\{\s*\}|[UI](?:8|16|32|64))"
     )
     output_lines = []
     for match in pattern.finditer(source):
-        name = match.group(1)
-        body = match.group(2)
-        if body.startswith("{"):
-            output_lines.append(f"void {name}(void) {{\n}}\n")
-            continue
-        value = "1" if body.lower() == "true" else "0"
-        output_lines.append(
-            f"int {name}(void) {{\n    return {value};\n}}\n"
-        )
+        name, body = match.group(1, 2)
+        output_lines.append(_translate_function(name, body))
     return "".join(output_lines)
 
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -34,3 +34,19 @@ def test_compile_boolean_functions(tmp_path):
         "int falsy(void) {\n    return 0;\n}\n"
     )
     assert output_file.read_text() == expected
+
+
+def test_compile_integer_functions(tmp_path):
+    src = "\n".join([
+        "fn byte() => U8",
+        "fn word() => I32",
+    ])
+    input_file = tmp_path / "in.mg"
+    input_file.write_text(src)
+    output_file = tmp_path / "out.c"
+    main(["-i", str(input_file), "-o", str(output_file)])
+    expected = (
+        "uint8_t byte(void) {\n    return 0;\n}\n"
+        "int32_t word(void) {\n    return 0;\n}\n"
+    )
+    assert output_file.read_text() == expected


### PR DESCRIPTION
## Summary
- implement `compile_source` support for integer types with CamelCase names
- document integer type functions in README
- test integer functions
- refactor compiler to limit nesting to two levels
- mention coding style in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687d0be3969083218425324ce691daf5