### PR TITLE
Support multiple parameters

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,3 +7,4 @@
 - Always run `pytest` and ensure the tests pass before committing changes.
 - Limit code to no more than two levels of nested structures such as loops or
   conditionals.
+- Avoid nested loops entirely. Do not place one `for` loop inside another.

--- a/README.md
+++ b/README.md
@@ -86,17 +86,24 @@ int32_t word(void) {
 }
 ```
 
-Functions may also take a single parameter inside the parentheses. A parameter
-is written as `name : Type`:
+Functions may also take one or more parameters inside the parentheses. Each
+parameter is written as `name : Type` and multiple parameters are separated by
+commas:
 
 ```magma
 fn id(x : I32) => I32
+
+fn add(x : I32, y : I32) => I32
 ```
 
 produces:
 
 ```c
 int32_t id(int32_t x) {
+    return 0;
+}
+
+int32_t add(int32_t x, int32_t y) {
     return 0;
 }
 ```
@@ -117,4 +124,4 @@ This project uses GitHub Actions to run the test suite on pushes and pull reques
 
 ## Coding Style
 
-Magmac keeps nested loops and conditionals to at most two levels of indentation so the code stays readable.
+Magmac avoids nested loops entirely and keeps other nested structures to at most two levels of indentation so the code stays readable.

--- a/magmac/compiler.py
+++ b/magmac/compiler.py
@@ -14,12 +14,12 @@ INT_TYPES = {
 
 
 def _translate_function(
-    name: str, body: str, param: tuple[str, str] | None = None
+    name: str, body: str, params: list[tuple[str, str]] | None = None
 ) -> str:
     """Return the C code for a single function declaration."""
-    if param:
-        p_name, p_type = param
-        param_decl = f"{INT_TYPES[p_type]} {p_name}"
+    if params:
+        parts = [f"{INT_TYPES[p_type]} {p_name}" for p_name, p_type in params]
+        param_decl = ", ".join(parts)
     else:
         param_decl = "void"
 
@@ -35,21 +35,16 @@ def _translate_function(
 def compile_source(source: str) -> str:
     """Compile a Magma source string to C code."""
     pattern = re.compile(
-        r"fn\s+(\w+)\s*\(\s*(\w+\s*:\s*[UI](?:8|16|32|64))?\s*\)\s*=>\s*(true|false|\{\s*\}|[UI](?:8|16|32|64))"
+        r"fn\s+(\w+)\s*\(\s*([^)]*)\)\s*=>\s*(true|false|\{\s*\}|[UI](?:8|16|32|64))"
     )
+    param_pattern = re.compile(r"(\w+)\s*:\s*([UI](?:8|16|32|64))")
     output_lines = []
-    for match in pattern.finditer(source):
-        name = match.group(1)
-        param_text = match.group(2)
-        body = match.group(3)
-        if param_text:
-            p_name, p_type = re.match(
-                r"(\w+)\s*:\s*([UI](?:8|16|32|64))", param_text
-            ).groups()
-            param = (p_name, p_type)
-        else:
-            param = None
-        output_lines.append(_translate_function(name, body, param))
+
+    for name, param_text, body in pattern.findall(source):
+        params = param_pattern.findall(param_text)
+        params_list = [tuple(p) for p in params] if params else None
+        output_lines.append(_translate_function(name, body, params_list))
+
     return "".join(output_lines)
 
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -60,3 +60,13 @@ def test_compile_single_parameter(tmp_path):
     main(["-i", str(input_file), "-o", str(output_file)])
     expected = "int32_t id(int32_t x) {\n    return 0;\n}\n"
     assert output_file.read_text() == expected
+
+
+def test_compile_multiple_parameters(tmp_path):
+    src = "fn add(x: I32, y: I32) => I32"
+    input_file = tmp_path / "in.mg"
+    input_file.write_text(src)
+    output_file = tmp_path / "out.c"
+    main(["-i", str(input_file), "-o", str(output_file)])
+    expected = "int32_t add(int32_t x, int32_t y) {\n    return 0;\n}\n"
+    assert output_file.read_text() == expected


### PR DESCRIPTION
## Summary
- refactor compiler implementation to remove nested loops
- document no nested loops standard in AGENTS and README
- keep parameter list support in README example

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687d150ce5f483218a160e5539da692e