### PR TITLE
Add integer type support with tests

### DIFF
--- a/magmac.c
+++ b/magmac.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
+#include <stdint.h>
 
 static void trim_space(char **p) {
     while (**p && isspace((unsigned char)**p)) {
@@ -29,6 +30,8 @@ int main(int argc, char *argv[]) {
         fclose(in);
         return EXIT_FAILURE;
     }
+
+    fprintf(out, "#include <stdint.h>\n\n");
 
     char line[1024];
     while (fgets(line, sizeof(line), in)) {
@@ -59,6 +62,22 @@ int main(int argc, char *argv[]) {
                         fprintf(out, "int %s() { return 1; }\n", name);
                     } else if (strncmp(p, "false", 5) == 0) {
                         fprintf(out, "int %s() { return 0; }\n", name);
+                    } else if (strncmp(p, "U8", 2) == 0) {
+                        fprintf(out, "uint8_t %s() { return 0; }\n", name);
+                    } else if (strncmp(p, "U16", 3) == 0) {
+                        fprintf(out, "uint16_t %s() { return 0; }\n", name);
+                    } else if (strncmp(p, "U32", 3) == 0) {
+                        fprintf(out, "uint32_t %s() { return 0; }\n", name);
+                    } else if (strncmp(p, "U64", 3) == 0) {
+                        fprintf(out, "uint64_t %s() { return 0; }\n", name);
+                    } else if (strncmp(p, "I8", 2) == 0) {
+                        fprintf(out, "int8_t %s() { return 0; }\n", name);
+                    } else if (strncmp(p, "I16", 3) == 0) {
+                        fprintf(out, "int16_t %s() { return 0; }\n", name);
+                    } else if (strncmp(p, "I32", 3) == 0) {
+                        fprintf(out, "int32_t %s() { return 0; }\n", name);
+                    } else if (strncmp(p, "I64", 3) == 0) {
+                        fprintf(out, "int64_t %s() { return 0; }\n", name);
                     }
                 }
             }

--- a/tests/test_int.sh
+++ b/tests/test_int.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+set -e
+
+gcc -std=c11 -Wall -Wextra -o magmac magmac.c
+
+TMPDIR=$(mktemp -d)
+
+echo 'fn get_u8() => U8' > "$TMPDIR/u8.mc"
+echo 'fn get_i64() => I64' > "$TMPDIR/i64.mc"
+
+./magmac "$TMPDIR/u8.mc" "$TMPDIR/u8.c"
+./magmac "$TMPDIR/i64.mc" "$TMPDIR/i64.c"
+
+grep -q 'uint8_t get_u8() { return 0; }' "$TMPDIR/u8.c"
+grep -q 'int64_t get_i64() { return 0; }' "$TMPDIR/i64.c"
+
+echo "Integer tests passed."
+rm -r "$TMPDIR"


### PR DESCRIPTION
## Summary
- include `<stdint.h>` and emit header in generated code
- implement U8/U16/U32/U64 and I8/I16/I32/I64 return types
- default numeric return value is `0`
- add tests verifying integer type handling

## Testing
- `bash tests/test_bool.sh`
- `bash tests/test_int.sh`


------
https://chatgpt.com/codex/tasks/task_e_687d22b6ab8c832199a4aa33f4f61080