### PR TITLE
Support explicit return type syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,17 @@
 # magmac
 
 This project contains a small translator written in C. It converts a very
-simple function syntax:
+simple function syntax. Functions can optionally specify an explicit return
+type after the parameter list.
 
 ```
 fn name() => {}
+```
+
+An explicit return type can be provided after the parameter list:
+
+```
+fn test(): I16 => {}
 ```
 
 into an equivalent empty C function:

--- a/magmac.c
+++ b/magmac.c
@@ -53,10 +53,33 @@ int main(int argc, char *argv[]) {
             if (*p == '(' && *(p + 1) == ')') {
                 p += 2;
                 trim_space(&p);
+                char ret_type[16] = "";
+                if (*p == ':') {
+                    p++;
+                    trim_space(&p);
+                    int j = 0;
+                    while (*p && !isspace((unsigned char)*p) && *p != '=' && j < (int)sizeof(ret_type) - 1) {
+                        ret_type[j++] = *p;
+                        p++;
+                    }
+                    ret_type[j] = '\0';
+                    trim_space(&p);
+                }
                 if (strncmp(p, "=>", 2) == 0) {
                     p += 2;
                     trim_space(&p);
-                    if (strncmp(p, "{}", 2) == 0) {
+                    const char *ctype = NULL;
+                    if (strcmp(ret_type, "U8") == 0) ctype = "uint8_t";
+                    else if (strcmp(ret_type, "U16") == 0) ctype = "uint16_t";
+                    else if (strcmp(ret_type, "U32") == 0) ctype = "uint32_t";
+                    else if (strcmp(ret_type, "U64") == 0) ctype = "uint64_t";
+                    else if (strcmp(ret_type, "I8") == 0) ctype = "int8_t";
+                    else if (strcmp(ret_type, "I16") == 0) ctype = "int16_t";
+                    else if (strcmp(ret_type, "I32") == 0) ctype = "int32_t";
+                    else if (strcmp(ret_type, "I64") == 0) ctype = "int64_t";
+                    if (ret_type[0] && ctype && strncmp(p, "{}", 2) == 0) {
+                        fprintf(out, "%s %s() {}\n", ctype, name);
+                    } else if (strncmp(p, "{}", 2) == 0) {
                         fprintf(out, "void %s() {}\n", name);
                     } else if (strncmp(p, "true", 4) == 0) {
                         fprintf(out, "int %s() { return 1; }\n", name);

--- a/tests/test_explicit_return.sh
+++ b/tests/test_explicit_return.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -e
+
+gcc -std=c11 -Wall -Wextra -o magmac magmac.c
+
+TMPDIR=$(mktemp -d)
+
+echo 'fn foo(): I16 => {}' > "$TMPDIR/explicit.mc"
+
+./magmac "$TMPDIR/explicit.mc" "$TMPDIR/explicit.c"
+
+grep -q 'int16_t foo() {}' "$TMPDIR/explicit.c"
+
+echo "Explicit return type test passed."
+rm -r "$TMPDIR"


### PR DESCRIPTION
## Summary
- allow an optional `:<type>` after the parameter list
- implement parsing of explicit return types in `magmac.c`
- document the new syntax in the README
- add a regression test for explicit return parsing

## Testing
- `./tests/test_bool.sh`
- `./tests/test_int.sh`
- `./tests/test_explicit_return.sh`


------
https://chatgpt.com/codex/tasks/task_e_687d2e0ec01c8321b1aafc1ca0b82298