### PR TITLE
Add simple compiler skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.class
+output.c

--- a/src/Magma.java
+++ b/src/Magma.java
@@ -1,0 +1,25 @@
+import java.io.*;
+
+public class Magma {
+    public static void main(String[] args) throws IOException {
+        // Determine source file path: assume this file is executed from project root
+        String sourceFile = "src/Magma.java";
+        if (args.length > 0) {
+            sourceFile = args[0];
+        }
+
+        // Read the source file (self)
+        try (BufferedReader reader = new BufferedReader(new FileReader(sourceFile))) {
+            while (reader.readLine() != null) {
+                // For now we simply read the lines without processing
+            }
+        }
+
+        // Output an empty C main function
+        try (PrintWriter writer = new PrintWriter(new FileWriter("output.c"))) {
+            writer.println("int main() {");
+            writer.println("    return 0;");
+            writer.println("}");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- provide an initial Java program `Magma` that reads its own source file
- write a placeholder C output containing an empty `main` function
- add `.gitignore` for build artifacts

## Testing
- `javac src/Magma.java && java -cp src Magma`


------
https://chatgpt.com/codex/tasks/task_e_687d546d7cb48321ba737dab0e01721b